### PR TITLE
use alpine version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,11 @@ services:
       RACK_ENV: test
       RAILS_ENV: test
   db-dev:
-    image: postgres
+    image: postgres:9.6-alpine
     environment:
       POSTGRES_DB: kokoroio_development
   db-test:
-    image: postgres
+    image: postgres:9.6-alpine
     environment:
       POSTGRES_DB: kokoroio_test
 volumes:


### PR DESCRIPTION
docker imageを軽量にするため、公式イメージをそのまま使っているpostgresを、alpineを使うバージョンに変更しました。