### PR TITLE
Added some constrains to be same as model definitions

### DIFF
--- a/db/migrate/20161215143522_add_constrains_to_rooms.rb
+++ b/db/migrate/20161215143522_add_constrains_to_rooms.rb
@@ -1,0 +1,9 @@
+class AddConstrainsToRooms < ActiveRecord::Migration[5.0]
+  def change
+    change_column :rooms, :room_name, :string, :limit => 64, :null => false
+    change_column :rooms, :screen_name, :string, :limit => 255, :null => false
+    change_column :rooms, :private, :boolean, :default => false, :null => false
+    change_column :rooms, :description, :text, :limit => 1000, :null => false
+    add_index :rooms, :room_name, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161204125620) do
+ActiveRecord::Schema.define(version: 20161215143522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,12 +73,13 @@ ActiveRecord::Schema.define(version: 20161204125620) do
   end
 
   create_table "rooms", force: :cascade do |t|
-    t.string   "room_name"
-    t.string   "screen_name"
-    t.boolean  "private"
+    t.string   "room_name",   limit: 64,                  null: false
+    t.string   "screen_name", limit: 255,                 null: false
+    t.boolean  "private",                 default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "description"
+    t.text     "description",                             null: false
+    t.index ["room_name"], name: "index_rooms_on_room_name", unique: true, using: :btree
     t.index ["screen_name"], name: "index_rooms_on_screen_name", unique: true, using: :btree
   end
 


### PR DESCRIPTION
とりあえず rooms に対してだけモデル定義のバリデーションとテーブル定義を合わせるようにしました。
ORM からしか更新しないにしても必要な対応かなとおもってますけど、どうなんだろう

あと room_name にユニークキー制約とインデックスはっつけたです。