### PR TITLE
空文字で送信しない

### DIFF
--- a/assets/javascripts/components/message-input/script.ts
+++ b/assets/javascripts/components/message-input/script.ts
@@ -48,8 +48,22 @@ export default {
         },
     },
 
+    watch: {
+        text(val, old) {
+            if (this.isBlank()) this.text = '';
+        }
+    },
+
     methods: {
+        isBlank() {
+            return !!/^\n$/.exec(this.text) || this.text.length === 0;
+        },
+
         maybeSay(evt: KeyboardEvent): boolean {
+            if (this.isBlank()) {
+                return false;
+                evt.preventDefault();
+            }
             switch(evt.keyCode || evt.which)
             {
                 case KeyCode.KEY_ENTER:


### PR DESCRIPTION
#229 

入力なしのエンターキー押下で何もアクションが起きないようにした

from https://github.com/supermomonga/kokoro-io/pull/232#issuecomment-300807938
>悩みどころではあるけど、チャットなので、たとえばAA貼ったりした時とか考えるとやはり入力したテキストはできるだけ勝手に改変が挟まれずそのままで表示されて欲しさがあるかな。同じ理由でホワイトスペース1個以上のみで構成される発言も許可したい。
>
> 空文字は流石に CR 押すだけで送られちゃうので誤爆防止で禁止したい、という感じ。